### PR TITLE
Line spacing correction on all <p> and <li> in .inner

### DIFF
--- a/src/components/Typography.astro
+++ b/src/components/Typography.astro
@@ -6,9 +6,10 @@ interface Props {
 }
 
 const { sans = false, small = false, class: className } = Astro.props;
+const lineHeight = sans ? "1.3em" : "1.5em";
 ---
 
-<div class="typography" class:list={[{ sans, small }, className]}>
+<div class="typography" class:list={[{ sans, small }, className]} style={{"--line-height": lineHeight}}>
   <div class="inner"><slot /></div>
 </div>
 
@@ -38,10 +39,10 @@ const { sans = false, small = false, class: className } = Astro.props;
     font-size: 1.1em;
   }
   .inner :global(p) {
-    line-height: 1.5em;
-  }
+    line-height: var(--line-height);
+  } 
   .inner :global(li) {
-    line-height: 1.5em;
+    line-height: var(--line-height);
   }
 
   @container (min-width: 500px) {

--- a/src/components/Typography.astro
+++ b/src/components/Typography.astro
@@ -37,6 +37,12 @@ const { sans = false, small = false, class: className } = Astro.props;
   .inner :global(h5) {
     font-size: 1.1em;
   }
+  .inner :global(p) {
+    line-height: 1.5em;
+  }
+  .inner :global(li) {
+    line-height: 1.5em;
+  }
 
   @container (min-width: 500px) {
     .inner {


### PR DESCRIPTION
- added css styling for <p> and <li> tags inside .inner.

note: i could have achieved a similar effect in less code by editing the line spacing in global.css, however decided a little less code wasn't worth the risk of site-wide css scope.